### PR TITLE
Implement a way to set the NRO that the next NRO will return to

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -422,6 +422,7 @@ void loadNro(void)
 
     if (!has_mod0) {
         // Apply sm-close workaround to NROs which do not contain a valid MOD0 header.
+        // This heuristic is based on the fact that MOD0 support was added very shortly after
         // the fix for the sm-close bug (in fact, two commits later).
         g_smCloseWorkaround = true;
     }


### PR DESCRIPTION
Don't merge this unless [this](https://github.com/switchbrew/libnx/pull/229) is merged first, otherwise this won't compile.

Like I said in that pull request, the variable names aren't ideal, but I don't know what else to call them.