### PR TITLE
Support automatic recording games on 4.0.0-4.1.0

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -198,7 +198,7 @@ static void getIsApplication(void) {
 
 //Gets the control.nacp for the current title id, and then sets g_isAutomaticGameplayRecording if less memory should be allocated.
 static void getIsAutomaticGameplayRecording(void) {
-    if (hosversionAtLeast(5,0,0) && g_isApplication) {
+    if (hosversionAtLeast(4,0,0) && g_isApplication) {
         Result rc=0;
         u64 cur_tid=0;
 


### PR DESCRIPTION
Current code will result in am throwing 2001-0125 (InvalidState) on < 5.0.0, when launching hbl under automatic-gameplay-recording titles.