### PR TITLE
Miscellaneous enhancements (incl. better ASLR support)

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -288,6 +288,8 @@ void loadNro(void)
         rw_size = header->segments[2].size + header->bss_size;
         rw_size = (rw_size+0xFFF) & ~0xFFF;
 
+        svcBreak(BreakReason_NotificationOnlyFlag | BreakReason_PreUnloadDll, g_nroAddr, g_nroSize);
+
         // .text
         rc = svcUnmapProcessCodeMemory(
             g_procHandle, g_nroAddr + header->segments[0].file_off, ((u64) g_heapAddr) + header->segments[0].file_off, header->segments[0].size);
@@ -309,6 +311,8 @@ void loadNro(void)
         if (R_FAILED(rc))
             fatalThrow(MAKERESULT(Module_HomebrewLoader, 26));
 
+        svcBreak(BreakReason_NotificationOnlyFlag | BreakReason_PostUnloadDll, g_nroAddr, g_nroSize);
+
         g_nroAddr = g_nroSize = 0;
     }
 
@@ -319,6 +323,8 @@ void loadNro(void)
     }
 
     memcpy(g_argv, g_nextArgv, sizeof g_argv);
+
+    svcBreak(BreakReason_NotificationOnlyFlag | BreakReason_PreLoadDll, (uintptr_t)g_argv, sizeof(g_argv));
 
     uint8_t *nrobuf = (uint8_t*) g_heapAddr;
 
@@ -462,6 +468,8 @@ void loadNro(void)
 
     g_nroAddr = (u64)map_addr;
     g_nroSize = nro_size;
+
+    svcBreak(BreakReason_NotificationOnlyFlag | BreakReason_PostLoadDll, g_nroAddr, g_nroSize);
 
     memset(__stack_top - STACK_SIZE, 0, STACK_SIZE);
 

--- a/source/main.c
+++ b/source/main.c
@@ -404,7 +404,7 @@ void loadNro(void)
 
     // Map code memory to a new randomized address
     virtmemLock();
-    void* map_addr = virtmemFindAslr(total_size, 0);
+    void* map_addr = virtmemFindCodeMemory(total_size, 0);
     rc = svcMapProcessCodeMemory(g_procHandle, (u64)map_addr, (u64)nrobuf, total_size);
     virtmemUnlock();
 


### PR DESCRIPTION
This is a companion PR of https://github.com/switchbrew/libnx/pull/500

Summary of changes:
- Improved ASLR support (it should now be possible to take advantage of the full 39-bit address space)
- CodeMemory syscalls are now revoked in the hinting list if the underlying kernel is incompatible with same-process JIT
- Removed workaround for very old NROs that had a bug in SM teardown handling
- Replaced fatals by process aborts
- Added NRO load/unload debugger breakpoint locations