### PR TITLE
Update NORETURN to NX_NORETURN for libnx 4.6.0+

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -44,7 +44,7 @@ bool __nx_fsdev_support_cwd = false;
 // Used by trampoline.s
 Result g_lastRet = 0;
 
-void NORETURN nroEntrypointTrampoline(const ConfigEntry* entries, u64 handle, u64 entrypoint);
+void NX_NORETURN nroEntrypointTrampoline(const ConfigEntry* entries, u64 handle, u64 entrypoint);
 
 void __libnx_initheap(void)
 {


### PR DESCRIPTION
I noticed that this is out of date, and that this reference needs to be updated for nx-hbloader to compile with c23 due to deprecation of NORETURN.

https://github.com/switchbrew/libnx/commit/a215ae2da2145fe3c68b65c1b4cf88033326d88a