### PR TITLE
Update debug flag to be consistent with 19.0.0+ requirements.

### DIFF
--- a/hbl.json
+++ b/hbl.json
@@ -245,7 +245,8 @@
         {
             "type": "debug_flags",
             "value": {
-                "allow_debug": true,
+                "allow_debug": false,
+                "force_debug_prod": false,
                 "force_debug": true
             }
         },


### PR DESCRIPTION
As noted in this commit: https://github.com/Atmosphere-NX/Atmosphere/commit/0c4ae5573153166e6eb026cc0da1bb41d77e194b#diff-8f4f075aef2c24447ccda4c26924401ac8ee494eb948d971e1116e8df73bda07R433

I personally find it silly for this just not to be fixed within hbl itself.

```cpp
/* 19.0.0+ disallows more than one flag set; we are always DebugMode for kernel, so ForceDebug is the most powerful/flexible flag to set. */
kac[i] = CapabilityDebugFlags::Encode(false, false, true);
```